### PR TITLE
feat(efiboot/list): allow to show a single namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "itertools",
  "paw",
  "structopt",
+ "uuid",
 ]
 
 [[package]]

--- a/efiboot/Cargo.toml
+++ b/efiboot/Cargo.toml
@@ -17,6 +17,7 @@ efivar = { version = "1.0.14", path = "../efivar", features = ["store"] }
 itertools = "0.10.5"
 paw = "1.0.0"
 structopt = { version = "0.3.26", features = ["paw"] }
+uuid = { version = "1.3.4" }
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }_{ target }{ archive-suffix }"

--- a/efiboot/src/cli/list.rs
+++ b/efiboot/src/cli/list.rs
@@ -1,10 +1,34 @@
-use efivar::VarManager;
+use efivar::{efi::VariableVendor, VarManager};
 
-pub fn run(enumerator: Box<dyn VarManager>) {
+fn list_all(enumerator: Box<dyn VarManager>) {
+    println!("{: >36} Variable", "Namespace");
     for var in enumerator
         .get_var_names()
         .expect("Failed to list variable names")
     {
-        println!("{}", var.short_name());
+        println!("{} {}", var.vendor(), var.variable());
+    }
+}
+
+fn list_namespace(enumerator: Box<dyn VarManager>, vendor: VariableVendor) {
+    println!("Variables in namespace {} :", vendor);
+    for var in enumerator
+        .get_var_names()
+        .expect("Failed to list variable names")
+    {
+        if var.vendor() == &vendor {
+            println!("{}", var.variable());
+        }
+    }
+}
+
+pub fn run(enumerator: Box<dyn VarManager>, namespace: Option<uuid::Uuid>, all: bool) {
+    if all {
+        list_all(enumerator);
+    } else {
+        list_namespace(
+            enumerator,
+            namespace.map_or(VariableVendor::Efi, VariableVendor::Custom),
+        );
     }
 }

--- a/efiboot/src/main.rs
+++ b/efiboot/src/main.rs
@@ -16,7 +16,14 @@ enum Command {
         string: bool,
     },
     /// List known EFI variables
-    List,
+    List {
+        /// GUID of the namespace. Default: EFI standard namespace
+        #[structopt(value_name = "GUID")]
+        namespace: Option<uuid::Uuid>,
+        /// ignore --namespace and show all namespaces
+        #[structopt(short, long)]
+        all: bool,
+    },
 }
 
 #[derive(StructOpt)]
@@ -48,8 +55,8 @@ fn main(opts: Opt) {
         Command::Read { name, string } => {
             cli::read(manager, &name, string);
         }
-        Command::List => {
-            cli::list(manager);
+        Command::List { namespace, all } => {
+            cli::list(manager, namespace, all);
         }
     }
 }


### PR DESCRIPTION
This PR changes the behaviour of `efiboot list` to allow you to show a single namespace

Examples :
### shows the standard EFI namespace
```
$ efiboot list
Variables in namespace 8be4df61-93ca-11d2-aa0d-00e098032b8c :
dbxDefault
dbDefault
KEKDefault
PKDefault
ConInDev
BootCurrent
ErrOutDev
ConOutDev
OsIndicationsSupported
PlatformLangCodes
LangCodes
VendorKeys
SignatureSupport
BootOrder
Boot0001
SecureBoot
SetupMode
Boot0003
Boot2003
Boot2002
Boot2001
ConOut
ConIn
Timeout
PlatformLang
Lang
```

### Shows a custom namespace
```
$ efiboot list 59d1c24f-50f1-401a-b101-f33e0daed443
Variables in namespace 59d1c24f-50f1-401a-b101-f33e0daed443 :
ActiveVgaDev
PhysicalBootOrder
CustomSecurity
certdb
RestoreFactoryDefault
UserVgaSelection
PsiSetupData
SecureBootEnforce
```

### Showing all variables from all namespaces
```
$ efiboot list --all
                           Namespace Variable
8be4df61-93ca-11d2-aa0d-00e098032b8c dbxDefault
8be4df61-93ca-11d2-aa0d-00e098032b8c dbDefault
8be4df61-93ca-11d2-aa0d-00e098032b8c KEKDefault
8be4df61-93ca-11d2-aa0d-00e098032b8c PKDefault
f72deef6-13ef-4958-b027-0e45ce7fa45e PasswordConfig
07a66697-d400-4903-b3da-67a61d2b7058 Tcg2ConfigInfo
aa1305b9-01f3-4afb-920e-c9b979a852fd SecureBootData
ef0849b6-fad0-40e9-9107-974aeb8787a2 VarEditFunDis
1f2d63e1-febd-4dc7-9cc5-ba2b1cef9c5b FeData
8be4df61-93ca-11d2-aa0d-00e098032b8c ConInDev
97d2f285-b16b-46d6-8aab-341a84a6e634 VarEdit
8be4df61-93ca-11d2-aa0d-00e098032b8c BootCurrent
8be4df61-93ca-11d2-aa0d-00e098032b8c ErrOutDev
59d1c24f-50f1-401a-b101-f33e0daed443 ActiveVgaDev
59d1c24f-50f1-401a-b101-f33e0daed443 ConOutCandidateDev
8be4df61-93ca-11d2-aa0d-00e098032b8c ConOutDev
79941ecd-ed36-49d0-8124-e4c31ac75cd4 AmdAcpiVar
59d1c24f-50f1-401a-b101-f33e0daed443 PlugInVgaHandles
59d1c24f-50f1-401a-b101-f33e0daed443 ConInCandidateDev
8be4df61-93ca-11d2-aa0d-00e098032b8c OsIndicationsSupported
8be4df61-93ca-11d2-aa0d-00e098032b8c PlatformLangCodes
8be4df61-93ca-11d2-aa0d-00e098032b8c LangCodes
8be4df61-93ca-11d2-aa0d-00e098032b8c VendorKeys
59d1c24f-50f1-401a-b101-f33e0daed443 certdbv
8be4df61-93ca-11d2-aa0d-00e098032b8c SignatureSupport
401984bb-989b-4baf-b568-495884120278 ResetFP
bb983ccf-151d-40e1-a07b-4a17be168292 MemoryOverwriteRequestControlLock
e20939be-32d4-41be-a150-897f85d49829 MemoryOverwriteRequestControl
f24643c2-c622-494e-8a0d-4632579c2d5b TrEEPhysicalPresence
a04a27f4-df00-4d42-b552-39511302113d Setup
d719b2cb-3d3a-4596-a3bc-dad00e67656f dbx
8be4df61-93ca-11d2-aa0d-00e098032b8c BootOrder
59d1c24f-50f1-401a-b101-f33e0daed443 PhysicalBootOrder
59d1c24f-50f1-401a-b101-f33e0daed443 TargetHddDevPath
8be4df61-93ca-11d2-aa0d-00e098032b8c Boot0001
8be4df61-93ca-11d2-aa0d-00e098032b8c SecureBoot
8be4df61-93ca-11d2-aa0d-00e098032b8c SetupMode
59d1c24f-50f1-401a-b101-f33e0daed443 CustomSecurity
8731426d-a9a7-cb76-3129-6e4e1e874120 H46SecureBootCheck
eaec226f-c9a3-477a-a826-ddc716cdc0e3 OfflineUniqueIDEKPubCRC
eaec226f-c9a3-477a-a826-ddc716cdc0e3 OfflineUniqueIDEKPub
8be4df61-93ca-11d2-aa0d-00e098032b8c Boot0003
eaec226f-c9a3-477a-a826-ddc716cdc0e3 UnlockIDCopy
77fa9abd-0359-4d32-bd60-28f4e78f784b CurrentPolicy
59d1c24f-50f1-401a-b101-f33e0daed443 certdb
59d1c24f-50f1-401a-b101-f33e0daed443 RestoreFactoryDefault
8be4df61-93ca-11d2-aa0d-00e098032b8c Boot2003
8be4df61-93ca-11d2-aa0d-00e098032b8c Boot2002
8be4df61-93ca-11d2-aa0d-00e098032b8c Boot2001
f24643c2-c622-494e-8a0d-4632579c2d5b TrEEPhysicalPresenceFlags
86bbf7e3-b772-4d22-80a9-e7c58c3c7ff0 SaveHddPassword
8be4df61-93ca-11d2-aa0d-00e098032b8c ConOut
8be4df61-93ca-11d2-aa0d-00e098032b8c ConIn
59d1c24f-50f1-401a-b101-f33e0daed443 UserVgaSelection
0ce40a5f-153a-4462-a429-4098e0e13cac ResourceDistribution
542b8f2f-bd52-4233-8c3d-66530de8a369 ResourceSizeForEachRb
ad22518b-450a-4857-96c3-d1e22f206129 MemCeil.
8731426d-a9a7-cb76-3129-6e4e1e874120 F12flag4
8731426d-a9a7-cb76-3129-6e4e1e874120 F12flag2
04b37fe8-f6ae-480b-bdd5-37d98c5e89aa VarErrorFlag
8376bdca-5e03-4735-951a-4a74141e5886 SetPcrBanks
a04a27f4-df00-4d42-b552-39511302113d Custom
c020489e-6db2-4ef2-9aa5-ca06fc11d36a AcpiGlobalVariable
8731426d-a9a7-cb76-3129-6e4e1e874120 H46MfgMode
8731426d-a9a7-cb76-3129-6e4e1e874120 PxeFlag
8be4df61-93ca-11d2-aa0d-00e098032b8c Timeout
59d1c24f-50f1-401a-b101-f33e0daed443 CustomPlatformLang
8731426d-a9a7-cb76-3129-6e4e1e874120 H46NextBootStatus
3a997502-647a-4c82-998e-52ef9486a247 AmdSetup
fe26a894-d199-47d4-8afa-070e3d54ba86 AMD_RAID
a339d746-f678-49b3-9fc7-54ce0f9df226 AMD_PBS_SETUP
382af2bb-ffff-abcd-aaee-cce099338877 SecureFlashInfo
8be4df61-93ca-11d2-aa0d-00e098032b8c PlatformLang
8be4df61-93ca-11d2-aa0d-00e098032b8c Lang
eb704011-1402-11d3-8e77-00a0c969723b MTC
aeb9c5c1-94f1-4d02-bfd9-4602db2d3c54 Tcg2PhysicalPresence
aeb9c5c1-94f1-4d02-bfd9-4602db2d3c54 Tcg2PhysicalPresenceFlags
59d1c24f-50f1-401a-b101-f33e0daed443 PsiSetupData
ad3f6761-f0a3-46c8-a4cb-19b70ffdb305 ApSyncFlagNv
8731426d-a9a7-cb76-3129-6e4e1e874120 H46ScuBootTypeOrder
24c38995-0940-4318-adeb-26bd5a2df237 OneKeyCheck
59d1c24f-50f1-401a-b101-f33e0daed443 SecureBootEnforce
29749bad-401b-4f6d-b124-cece8c590c48 DownCoreStatus
```