### PR TITLE
chore(efivar): fix clippy warnings

### DIFF
--- a/efivar/src/store/memory.rs
+++ b/efivar/src/store/memory.rs
@@ -42,11 +42,7 @@ mod tests {
     fn missing_variable() {
         let mut store = MemoryStore::new();
         store
-            .write(
-                &VariableName::new("BootOrder"),
-                VariableFlags::empty(),
-                &vec![],
-            )
+            .write(&VariableName::new("BootOrder"), VariableFlags::empty(), &[])
             .unwrap();
 
         let group = store
@@ -60,11 +56,7 @@ mod tests {
     fn existing_variable() {
         let mut store = MemoryStore::new();
         store
-            .write(
-                &VariableName::new("BootOrder"),
-                VariableFlags::empty(),
-                &vec![],
-            )
+            .write(&VariableName::new("BootOrder"), VariableFlags::empty(), &[])
             .unwrap();
 
         let group = store

--- a/efivar/src/sys/linux.rs
+++ b/efivar/src/sys/linux.rs
@@ -92,7 +92,7 @@ mod tests {
 
         let mut var_names = manager.get_var_names().unwrap();
         let name = VariableName::new("BootOrder");
-        assert!(var_names.find(|n| *n == name).is_some());
+        assert!(var_names.any(|n| n == name));
     }
 
     fn linux_read_var(manager: &SystemManager) {


### PR DESCRIPTION
For some reason, these warnings are not shown by cargo clippy in this project, but are highlighted by vscode, maybe that's why they went undetected ?