### PR TITLE
feat: Add boot subcommands to read boot entries

### DIFF
--- a/efiboot/src/cli.rs
+++ b/efiboot/src/cli.rs
@@ -1,4 +1,7 @@
+mod boot;
 mod list;
 mod read;
+
+pub use self::boot::get_order as get_boot_order;
 pub use self::list::run as list;
 pub use self::read::run as read;

--- a/efiboot/src/cli.rs
+++ b/efiboot/src/cli.rs
@@ -2,6 +2,7 @@ mod boot;
 mod list;
 mod read;
 
+pub use self::boot::get_entries as get_boot_entries;
 pub use self::boot::get_order as get_boot_order;
 pub use self::list::run as list;
 pub use self::read::run as read;

--- a/efiboot/src/cli/boot.rs
+++ b/efiboot/src/cli/boot.rs
@@ -1,0 +1,3 @@
+mod get_order;
+
+pub use get_order::get_order;

--- a/efiboot/src/cli/boot.rs
+++ b/efiboot/src/cli/boot.rs
@@ -1,3 +1,5 @@
+mod get_entries;
 mod get_order;
 
+pub use get_entries::get_entries;
 pub use get_order::get_order;

--- a/efiboot/src/cli/boot/get_entries.rs
+++ b/efiboot/src/cli/boot/get_entries.rs
@@ -1,6 +1,6 @@
 use efivar::VarManager;
 
-pub fn get_entries(manager: Box<dyn VarManager>) {
+pub fn get_entries(manager: Box<dyn VarManager>, verbose: bool) {
     let entries = match manager.get_boot_entries() {
         Ok(entries) => entries,
         Err(err) => {
@@ -19,6 +19,17 @@ pub fn get_entries(manager: Box<dyn VarManager>) {
             println!("Boot file: {}", file_path_list);
         } else {
             println!("No valid boot file location");
+        }
+        if verbose && !entry.optional_data.is_empty() {
+            println!(
+                "Optional data: {}",
+                entry
+                    .optional_data
+                    .iter()
+                    .map(|b| format!("{:02x}", b))
+                    .collect::<Vec<String>>()
+                    .join(" ")
+            );
         }
     }
 }

--- a/efiboot/src/cli/boot/get_entries.rs
+++ b/efiboot/src/cli/boot/get_entries.rs
@@ -12,47 +12,54 @@ pub fn get_entries(manager: Box<dyn VarManager>, verbose: bool) {
     println!("Boot entries (in boot order):");
 
     for entry in entries {
-        println!();
+        match entry {
+            Ok(entry) => {
+                println!();
 
-        println!("Description: {}", entry.description);
-        println!(
-            "Enabled: {}",
-            entry
-                .attributes
-                .contains(BootEntryAttributes::LOAD_OPTION_ACTIVE)
-        );
-
-        println!(
-            "Boot file: {}",
-            entry
-                .file_path_list
-                .map(|fpl| fpl.to_string())
-                .unwrap_or_else(|| "None/Invalid".to_owned())
-        );
-
-        if verbose {
-            println!(
-                "Optional data: {}",
-                if entry.optional_data.is_empty() {
-                    "None".to_owned()
-                } else {
+                println!("Description: {}", entry.description);
+                println!(
+                    "Enabled: {}",
                     entry
-                        .optional_data
-                        .iter()
-                        .map(|b| format!("{:02x}", b))
-                        .collect::<Vec<String>>()
-                        .join(" ")
-                }
-            );
+                        .attributes
+                        .contains(BootEntryAttributes::LOAD_OPTION_ACTIVE)
+                );
 
-            println!(
-                "Attributes: {}",
-                if entry.attributes.is_empty() {
-                    "None".to_owned()
-                } else {
-                    entry.attributes.to_string()
+                println!(
+                    "Boot file: {}",
+                    entry
+                        .file_path_list
+                        .map(|fpl| fpl.to_string())
+                        .unwrap_or_else(|| "None/Invalid".to_owned())
+                );
+
+                if verbose {
+                    println!(
+                        "Optional data: {}",
+                        if entry.optional_data.is_empty() {
+                            "None".to_owned()
+                        } else {
+                            entry
+                                .optional_data
+                                .iter()
+                                .map(|b| format!("{:02x}", b))
+                                .collect::<Vec<String>>()
+                                .join(" ")
+                        }
+                    );
+
+                    println!(
+                        "Attributes: {}",
+                        if entry.attributes.is_empty() {
+                            "None".to_owned()
+                        } else {
+                            entry.attributes.to_string()
+                        }
+                    );
                 }
-            );
+            }
+            Err(err) => {
+                eprintln!("Failed to get entry: {}", err);
+            }
         }
     }
 }

--- a/efiboot/src/cli/boot/get_entries.rs
+++ b/efiboot/src/cli/boot/get_entries.rs
@@ -13,23 +13,28 @@ pub fn get_entries(manager: Box<dyn VarManager>, verbose: bool) {
 
     for entry in entries {
         println!("--");
-        println!("Attributes: {}", entry.attributes);
         println!("Description: {:?}", entry.description);
         if let Some(file_path_list) = entry.file_path_list {
             println!("Boot file: {}", file_path_list);
         } else {
             println!("No valid boot file location");
         }
-        if verbose && !entry.optional_data.is_empty() {
-            println!(
-                "Optional data: {}",
-                entry
-                    .optional_data
-                    .iter()
-                    .map(|b| format!("{:02x}", b))
-                    .collect::<Vec<String>>()
-                    .join(" ")
-            );
+        if verbose {
+            if !entry.optional_data.is_empty() {
+                println!(
+                    "Optional data: {}",
+                    entry
+                        .optional_data
+                        .iter()
+                        .map(|b| format!("{:02x}", b))
+                        .collect::<Vec<String>>()
+                        .join(" ")
+                );
+            }
+
+            if !entry.attributes.is_empty() {
+                println!("Attributes: {}", entry.attributes);
+            }
         }
     }
 }

--- a/efiboot/src/cli/boot/get_entries.rs
+++ b/efiboot/src/cli/boot/get_entries.rs
@@ -11,7 +11,14 @@ pub fn get_entries(manager: Box<dyn VarManager>) {
 
     println!("Boot entries (in boot order):");
 
-    for _entry in entries {
-        println!("Some entry");
+    for entry in entries {
+        println!("--");
+        println!("Attributes: {:?}", entry.attributes);
+        println!("Description: {:?}", entry.description);
+        if let Some(file_path_list) = entry.file_path_list {
+            println!("Boot file: {}", file_path_list);
+        } else {
+            println!("No valid boot file location");
+        }
     }
 }

--- a/efiboot/src/cli/boot/get_entries.rs
+++ b/efiboot/src/cli/boot/get_entries.rs
@@ -21,11 +21,14 @@ pub fn get_entries(manager: Box<dyn VarManager>, verbose: bool) {
                 .contains(BootEntryAttributes::LOAD_OPTION_ACTIVE)
         );
 
-        if let Some(file_path_list) = entry.file_path_list {
-            println!("Boot file: {}", file_path_list);
-        } else {
-            println!("No valid boot file location");
-        }
+        println!(
+            "Boot file: {}",
+            entry
+                .file_path_list
+                .map(|fpl| fpl.to_string())
+                .unwrap_or_else(|| "None/Invalid".to_owned())
+        );
+
         if verbose {
             if !entry.optional_data.is_empty() {
                 println!(

--- a/efiboot/src/cli/boot/get_entries.rs
+++ b/efiboot/src/cli/boot/get_entries.rs
@@ -13,7 +13,7 @@ pub fn get_entries(manager: Box<dyn VarManager>, verbose: bool) {
 
     for entry in entries {
         println!("--");
-        println!("Attributes: {:?}", entry.attributes);
+        println!("Attributes: {}", entry.attributes);
         println!("Description: {:?}", entry.description);
         if let Some(file_path_list) = entry.file_path_list {
             println!("Boot file: {}", file_path_list);

--- a/efiboot/src/cli/boot/get_entries.rs
+++ b/efiboot/src/cli/boot/get_entries.rs
@@ -1,4 +1,4 @@
-use efivar::VarManager;
+use efivar::{boot::BootEntryAttributes, VarManager};
 
 pub fn get_entries(manager: Box<dyn VarManager>, verbose: bool) {
     let entries = match manager.get_boot_entries() {
@@ -14,6 +14,13 @@ pub fn get_entries(manager: Box<dyn VarManager>, verbose: bool) {
     for entry in entries {
         println!("--");
         println!("Description: {:?}", entry.description);
+        println!(
+            "Enabled: {:?}",
+            entry
+                .attributes
+                .contains(BootEntryAttributes::LOAD_OPTION_ACTIVE)
+        );
+
         if let Some(file_path_list) = entry.file_path_list {
             println!("Boot file: {}", file_path_list);
         } else {

--- a/efiboot/src/cli/boot/get_entries.rs
+++ b/efiboot/src/cli/boot/get_entries.rs
@@ -14,9 +14,9 @@ pub fn get_entries(manager: Box<dyn VarManager>, verbose: bool) {
     for entry in entries {
         println!();
 
-        println!("Description: {:?}", entry.description);
+        println!("Description: {}", entry.description);
         println!(
-            "Enabled: {:?}",
+            "Enabled: {}",
             entry
                 .attributes
                 .contains(BootEntryAttributes::LOAD_OPTION_ACTIVE)

--- a/efiboot/src/cli/boot/get_entries.rs
+++ b/efiboot/src/cli/boot/get_entries.rs
@@ -30,21 +30,28 @@ pub fn get_entries(manager: Box<dyn VarManager>, verbose: bool) {
         );
 
         if verbose {
-            if !entry.optional_data.is_empty() {
-                println!(
-                    "Optional data: {}",
+            println!(
+                "Optional data: {}",
+                if entry.optional_data.is_empty() {
+                    "None".to_owned()
+                } else {
                     entry
                         .optional_data
                         .iter()
                         .map(|b| format!("{:02x}", b))
                         .collect::<Vec<String>>()
                         .join(" ")
-                );
-            }
+                }
+            );
 
-            if !entry.attributes.is_empty() {
-                println!("Attributes: {}", entry.attributes);
-            }
+            println!(
+                "Attributes: {}",
+                if entry.attributes.is_empty() {
+                    "None".to_owned()
+                } else {
+                    entry.attributes.to_string()
+                }
+            );
         }
     }
 }

--- a/efiboot/src/cli/boot/get_entries.rs
+++ b/efiboot/src/cli/boot/get_entries.rs
@@ -12,7 +12,8 @@ pub fn get_entries(manager: Box<dyn VarManager>, verbose: bool) {
     println!("Boot entries (in boot order):");
 
     for entry in entries {
-        println!("--");
+        println!();
+
         println!("Description: {:?}", entry.description);
         println!(
             "Enabled: {:?}",

--- a/efiboot/src/cli/boot/get_entries.rs
+++ b/efiboot/src/cli/boot/get_entries.rs
@@ -1,0 +1,17 @@
+use efivar::VarManager;
+
+pub fn get_entries(manager: Box<dyn VarManager>) {
+    let entries = match manager.get_boot_entries() {
+        Ok(entries) => entries,
+        Err(err) => {
+            eprintln!("Failed to get boot entries: {}", err);
+            return;
+        }
+    };
+
+    println!("Boot entries (in boot order):");
+
+    for _entry in entries {
+        println!("Some entry");
+    }
+}

--- a/efiboot/src/cli/boot/get_order.rs
+++ b/efiboot/src/cli/boot/get_order.rs
@@ -1,0 +1,17 @@
+use efivar::VarManager;
+
+pub fn get_order(manager: Box<dyn VarManager>) {
+    let entries = match manager.get_boot_order() {
+        Ok(entries) => entries,
+        Err(err) => {
+            eprintln!("Failed to get boot order IDs: {}", err);
+            return;
+        }
+    };
+
+    println!("Boot order:");
+
+    for entry in entries {
+        println!("{}", entry.variable());
+    }
+}

--- a/efiboot/src/main.rs
+++ b/efiboot/src/main.rs
@@ -7,6 +7,7 @@ use structopt::StructOpt;
 enum BootCommand {
     /// Get current boot order IDs. See get-entries to get boot entries information
     GetOrder,
+    GetEntries,
 }
 
 #[derive(StructOpt)]
@@ -70,6 +71,9 @@ fn main(opts: Opt) {
         Command::Boot(arg) => match arg {
             BootCommand::GetOrder => {
                 cli::get_boot_order(manager);
+            }
+            BootCommand::GetEntries => {
+                cli::get_boot_entries(manager);
             }
         },
     }

--- a/efiboot/src/main.rs
+++ b/efiboot/src/main.rs
@@ -4,6 +4,12 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
+enum BootCommand {
+    /// Get current boot order IDs. See get-entries to get boot entries information
+    GetOrder,
+}
+
+#[derive(StructOpt)]
 enum Command {
     /// Read the value of a variable
     Read {
@@ -24,6 +30,9 @@ enum Command {
         #[structopt(short, long)]
         all: bool,
     },
+
+    /// Manage boot-related variables
+    Boot(BootCommand),
 }
 
 #[derive(StructOpt)]
@@ -58,5 +67,10 @@ fn main(opts: Opt) {
         Command::List { namespace, all } => {
             cli::list(manager, namespace, all);
         }
+        Command::Boot(arg) => match arg {
+            BootCommand::GetOrder => {
+                cli::get_boot_order(manager);
+            }
+        },
     }
 }

--- a/efiboot/src/main.rs
+++ b/efiboot/src/main.rs
@@ -7,7 +7,11 @@ use structopt::StructOpt;
 enum BootCommand {
     /// Get current boot order IDs. See get-entries to get boot entries information
     GetOrder,
-    GetEntries,
+    GetEntries {
+        /// Show more information, such as optional data
+        #[structopt(short, long)]
+        verbose: bool,
+    },
 }
 
 #[derive(StructOpt)]
@@ -72,8 +76,8 @@ fn main(opts: Opt) {
             BootCommand::GetOrder => {
                 cli::get_boot_order(manager);
             }
-            BootCommand::GetEntries => {
-                cli::get_boot_entries(manager);
+            BootCommand::GetEntries { verbose } => {
+                cli::get_boot_entries(manager, verbose);
             }
         },
     }

--- a/efivar/src/boot.rs
+++ b/efivar/src/boot.rs
@@ -1,0 +1,3 @@
+mod boot_reader;
+
+pub use boot_reader::BootVarReader;

--- a/efivar/src/boot.rs
+++ b/efivar/src/boot.rs
@@ -2,5 +2,7 @@ mod boot_entries_reader;
 mod boot_entry_parser;
 mod boot_order_reader;
 mod boot_var_reader;
+mod parse;
 
 pub use boot_var_reader::BootVarReader;
+pub use parse::FilePathList;

--- a/efivar/src/boot.rs
+++ b/efivar/src/boot.rs
@@ -1,3 +1,6 @@
-mod boot_reader;
+mod boot_entries_reader;
+mod boot_entry_parser;
+mod boot_order_reader;
+mod boot_var_reader;
 
-pub use boot_reader::BootVarReader;
+pub use boot_var_reader::BootVarReader;

--- a/efivar/src/boot.rs
+++ b/efivar/src/boot.rs
@@ -4,5 +4,6 @@ mod boot_order_reader;
 mod boot_var_reader;
 mod parse;
 
+pub use boot_entry_parser::BootEntryAttributes;
 pub use boot_var_reader::BootVarReader;
 pub use parse::FilePathList;

--- a/efivar/src/boot/boot_entries_reader.rs
+++ b/efivar/src/boot/boot_entries_reader.rs
@@ -2,12 +2,12 @@ use crate::VarReader;
 
 use super::{boot_entry_parser::BootEntry, boot_order_reader::BootOrderIterator};
 
+/// Loop over boot entries. On each iteration, a variable data will be queried from the OS
 pub struct BootEntriesIterator<'a> {
     order_iter: BootOrderIterator,
     var_reader: &'a dyn VarReader,
 }
 
-/// Loop over boot entries. On each iteration, a variable data will be queried from the OS
 impl<'a> BootEntriesIterator<'a> {
     pub(in super::super) fn new(
         var_reader: &'a dyn VarReader,

--- a/efivar/src/boot/boot_entries_reader.rs
+++ b/efivar/src/boot/boot_entries_reader.rs
@@ -1,0 +1,30 @@
+use crate::VarReader;
+
+use super::{boot_entry_parser::BootEntry, boot_order_reader::BootOrderIterator};
+
+pub struct BootEntriesIterator<'a> {
+    order_iter: BootOrderIterator,
+    var_reader: &'a dyn VarReader,
+}
+
+/// Loop over boot order IDs. The corresponding entries are not queried
+impl<'a> BootEntriesIterator<'a> {
+    pub(in super::super) fn new(
+        var_reader: &'a dyn VarReader,
+    ) -> crate::Result<BootEntriesIterator<'a>> {
+        Ok(BootEntriesIterator {
+            order_iter: BootOrderIterator::new(var_reader)?,
+            var_reader,
+        })
+    }
+}
+
+impl<'a> Iterator for BootEntriesIterator<'a> {
+    type Item = BootEntry;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.order_iter
+            .next()
+            .map(|var| BootEntry::parse(self.var_reader, &var))
+    }
+}

--- a/efivar/src/boot/boot_entries_reader.rs
+++ b/efivar/src/boot/boot_entries_reader.rs
@@ -20,7 +20,7 @@ impl<'a> BootEntriesIterator<'a> {
 }
 
 impl<'a> Iterator for BootEntriesIterator<'a> {
-    type Item = BootEntry;
+    type Item = Result<BootEntry, crate::Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.order_iter

--- a/efivar/src/boot/boot_entries_reader.rs
+++ b/efivar/src/boot/boot_entries_reader.rs
@@ -7,7 +7,7 @@ pub struct BootEntriesIterator<'a> {
     var_reader: &'a dyn VarReader,
 }
 
-/// Loop over boot order IDs. The corresponding entries are not queried
+/// Loop over boot entries. On each iteration, a variable data will be queried from the OS
 impl<'a> BootEntriesIterator<'a> {
     pub(in super::super) fn new(
         var_reader: &'a dyn VarReader,

--- a/efivar/src/boot/boot_entry_parser.rs
+++ b/efivar/src/boot/boot_entry_parser.rs
@@ -1,19 +1,68 @@
-use std::io::Cursor;
+use std::io::Read;
+
+use byteorder::{LittleEndian, ReadBytesExt};
 
 use crate::{efi::VariableName, VarReader};
 
-pub struct BootEntry {}
+use super::FilePathList;
+
+bitflags! {
+    /// Possible attributes of a boot entry as a bitfield
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct BootEntryAttributes : u32 {
+        const LOAD_OPTION_ACTIVE = 0x1;
+        const LOAD_OPTION_FORCE_RECONNECT = 0x2;
+        const LOAD_OPTION_HIDDEN = 0x8;
+        const LOAD_OPTION_CATEGORY_APP = 0x100;
+    }
+}
+
+pub fn read_nt_utf16_string(cursor: &mut &[u8]) -> String {
+    let mut vec: Vec<u16> = vec![];
+    loop {
+        match cursor.read_u16::<LittleEndian>().unwrap() {
+            0 => {
+                return String::from_utf16(&vec).unwrap();
+            }
+            chr => {
+                vec.push(chr);
+            }
+        }
+    }
+}
+
+pub struct BootEntry {
+    pub attributes: BootEntryAttributes,
+    pub description: String,
+    pub file_path_list: Option<FilePathList>,
+}
 
 impl BootEntry {
     pub fn parse(manager: &(impl ?Sized + VarReader), variable: &VariableName) -> Self {
-        let mut buf = vec![0u8; 512];
+        let mut conrete_buf = vec![0u8; 512];
 
-        let (written_size, _flags) = manager.read(variable, &mut buf).unwrap();
+        let (written_size, _flags) = manager.read(variable, &mut conrete_buf).unwrap();
 
-        buf.resize(written_size, 0);
+        conrete_buf.resize(written_size, 0);
+        // slice of the buffer
+        // Used so we can move the offset in it with ReadBytesExt functions
+        let mut buf = &conrete_buf[..];
 
-        let cursor = Cursor::new(buf);
+        let attributes = buf.read_u32::<LittleEndian>().unwrap();
 
-        todo!();
+        let file_path_list_length = buf.read_u16::<LittleEndian>().unwrap();
+
+        let description = read_nt_utf16_string(&mut buf);
+
+        let mut file_path_list_buf = vec![0u8; file_path_list_length.into()];
+        buf.read_exact(&mut file_path_list_buf).unwrap();
+
+        let file_path_list = FilePathList::parse(&mut &file_path_list_buf[..]);
+
+        BootEntry {
+            attributes: BootEntryAttributes::from_bits(attributes).unwrap(),
+            description,
+            file_path_list,
+        }
     }
 }

--- a/efivar/src/boot/boot_entry_parser.rs
+++ b/efivar/src/boot/boot_entry_parser.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::{fmt::Display, io::Read};
 
 use byteorder::{LittleEndian, ReadBytesExt};
 
@@ -14,6 +14,12 @@ bitflags! {
         const LOAD_OPTION_FORCE_RECONNECT = 0x2;
         const LOAD_OPTION_HIDDEN = 0x8;
         const LOAD_OPTION_CATEGORY_APP = 0x100;
+    }
+}
+
+impl Display for BootEntryAttributes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, f)
     }
 }
 

--- a/efivar/src/boot/boot_entry_parser.rs
+++ b/efivar/src/boot/boot_entry_parser.rs
@@ -1,0 +1,19 @@
+use std::io::Cursor;
+
+use crate::{efi::VariableName, VarReader};
+
+pub struct BootEntry {}
+
+impl BootEntry {
+    pub fn parse(manager: &(impl ?Sized + VarReader), variable: &VariableName) -> Self {
+        let mut buf = vec![0u8; 512];
+
+        let (written_size, _flags) = manager.read(variable, &mut buf).unwrap();
+
+        buf.resize(written_size, 0);
+
+        let cursor = Cursor::new(buf);
+
+        todo!();
+    }
+}

--- a/efivar/src/boot/boot_entry_parser.rs
+++ b/efivar/src/boot/boot_entry_parser.rs
@@ -35,6 +35,7 @@ pub struct BootEntry {
     pub attributes: BootEntryAttributes,
     pub description: String,
     pub file_path_list: Option<FilePathList>,
+    pub optional_data: Vec<u8>,
 }
 
 impl BootEntry {
@@ -63,6 +64,7 @@ impl BootEntry {
             attributes: BootEntryAttributes::from_bits(attributes).unwrap(),
             description,
             file_path_list,
+            optional_data: buf.to_vec(),
         }
     }
 }

--- a/efivar/src/boot/boot_order_reader.rs
+++ b/efivar/src/boot/boot_order_reader.rs
@@ -10,7 +10,7 @@ pub struct BootOrderIterator {
 
 /// Loop over boot order IDs. The corresponding entries are not queried
 impl BootOrderIterator {
-    fn new(sm: &impl VarReader) -> crate::Result<BootOrderIterator> {
+    pub(in super::super) fn new(sm: &dyn VarReader) -> crate::Result<BootOrderIterator> {
         // Buffer for BootOrder
         let mut buf = vec![0u8; 512];
 
@@ -34,15 +34,5 @@ impl Iterator for BootOrderIterator {
             .read_u16::<LittleEndian>()
             .map(|id| VariableName::new(&format!("Boot{:04X}", id)))
             .ok()
-    }
-}
-
-pub trait BootVarReader {
-    fn get_boot_order(&self) -> crate::Result<BootOrderIterator>;
-}
-
-impl<T: VarReader> BootVarReader for T {
-    fn get_boot_order(&self) -> crate::Result<BootOrderIterator> {
-        BootOrderIterator::new(self)
     }
 }

--- a/efivar/src/boot/boot_order_reader.rs
+++ b/efivar/src/boot/boot_order_reader.rs
@@ -4,11 +4,11 @@ use byteorder::{LittleEndian, ReadBytesExt};
 
 use crate::{efi::VariableName, VarReader};
 
+/// Loop over boot order IDs. The corresponding entries are not queried
 pub struct BootOrderIterator {
     cursor: Cursor<Vec<u8>>,
 }
 
-/// Loop over boot order IDs. The corresponding entries are not queried
 impl BootOrderIterator {
     pub(in super::super) fn new(sm: &dyn VarReader) -> crate::Result<BootOrderIterator> {
         // Buffer for BootOrder

--- a/efivar/src/boot/boot_reader.rs
+++ b/efivar/src/boot/boot_reader.rs
@@ -1,0 +1,48 @@
+use std::io::Cursor;
+
+use byteorder::{LittleEndian, ReadBytesExt};
+
+use crate::{efi::VariableName, VarReader};
+
+pub struct BootOrderIterator {
+    cursor: Cursor<Vec<u8>>,
+}
+
+/// Loop over boot order IDs. The corresponding entries are not queried
+impl BootOrderIterator {
+    fn new(sm: &impl VarReader) -> crate::Result<BootOrderIterator> {
+        // Buffer for BootOrder
+        let mut buf = vec![0u8; 512];
+
+        // Read BootOrder
+        let (boot_order_size, _flags) = sm.read(&VariableName::new("BootOrder"), &mut buf[..])?;
+
+        // Resize to actual value size
+        buf.resize(boot_order_size, 0);
+
+        Ok(BootOrderIterator {
+            cursor: Cursor::new(buf),
+        })
+    }
+}
+
+impl Iterator for BootOrderIterator {
+    type Item = VariableName;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.cursor
+            .read_u16::<LittleEndian>()
+            .map(|id| VariableName::new(&format!("Boot{:04X}", id)))
+            .ok()
+    }
+}
+
+pub trait BootVarReader {
+    fn get_boot_order(&self) -> crate::Result<BootOrderIterator>;
+}
+
+impl<T: VarReader> BootVarReader for T {
+    fn get_boot_order(&self) -> crate::Result<BootOrderIterator> {
+        BootOrderIterator::new(self)
+    }
+}

--- a/efivar/src/boot/boot_var_reader.rs
+++ b/efivar/src/boot/boot_var_reader.rs
@@ -1,0 +1,18 @@
+use crate::VarReader;
+
+use super::{boot_entries_reader::BootEntriesIterator, boot_order_reader::BootOrderIterator};
+
+pub trait BootVarReader {
+    fn get_boot_order(&self) -> crate::Result<BootOrderIterator>;
+    fn get_boot_entries(&self) -> crate::Result<BootEntriesIterator>;
+}
+
+impl<T: VarReader> BootVarReader for T {
+    fn get_boot_order(&self) -> crate::Result<BootOrderIterator> {
+        BootOrderIterator::new(self)
+    }
+
+    fn get_boot_entries(&self) -> crate::Result<BootEntriesIterator> {
+        BootEntriesIterator::new(self)
+    }
+}

--- a/efivar/src/boot/parse.rs
+++ b/efivar/src/boot/parse.rs
@@ -1,0 +1,7 @@
+mod consts;
+mod device_path;
+mod device_path_list;
+
+pub use device_path::DevicePath;
+pub use device_path::EFIHardDrive;
+pub use device_path_list::FilePathList;

--- a/efivar/src/boot/parse/consts.rs
+++ b/efivar/src/boot/parse/consts.rs
@@ -1,0 +1,26 @@
+/// Holds magic numbers of the different subtypes for the device path type MEDIA_DEVICE_PATH
+#[allow(unused)]
+#[allow(non_snake_case)] // module only holds constants
+pub mod MEDIA_DEVICE_PATH_SUBTYPE {
+    pub const HARD_DRIVE: u8 = 0x01;
+    pub const CD_ROM: u8 = 0x02;
+    pub const VENDOR: u8 = 0x03;
+    pub const FILE_PATH: u8 = 0x04;
+    pub const MEDIA_PROTOCOL: u8 = 0x05;
+    pub const PIWG_FIRMWARE_FILE: u8 = 0x06;
+    pub const PIWG_FIRMWARE_VOLUME: u8 = 0x07;
+    pub const RELATIVE_OFFSET_RANGE: u8 = 0x08;
+    pub const RAM_DISK_DEVICE_PATH: u8 = 0x09;
+}
+
+/// Holds magic numbers of the different types of device path types
+#[allow(unused)]
+#[allow(non_snake_case)] // module only holds constants
+pub mod DEVICE_PATH_TYPE {
+    pub const HARDWARE_DEVICE_PATH: u8 = 0x01;
+    pub const ACPI_DEVICE_PATH: u8 = 0x02;
+    pub const MESSAGING_DEVICE_PATH: u8 = 0x03;
+    pub const MEDIA_DEVICE_PATH: u8 = 0x04;
+    pub const BIOS_BOOT_SPECIFICATION_DEVICE_PATH: u8 = 0x05;
+    pub const END_OF_HARDWARE_DEVICE_PATH: u8 = 0x7F;
+}

--- a/efivar/src/boot/parse/device_path.rs
+++ b/efivar/src/boot/parse/device_path.rs
@@ -1,0 +1,78 @@
+use std::fmt::Display;
+
+use byteorder::{LittleEndian, ReadBytesExt};
+use uuid::Uuid;
+
+use crate::boot::boot_entry_parser::read_nt_utf16_string;
+
+use super::consts;
+
+pub enum DevicePath {
+    FilePath(std::path::PathBuf),
+    HardDrive(EFIHardDrive),
+}
+
+pub struct EFIHardDrive {
+    pub partition_number: u32,
+    pub partition_start: u64,
+    pub partition_size: u64,
+    pub partition_sig: Uuid,
+    pub format: u8,
+    pub sig_type: u8,
+}
+
+impl Display for EFIHardDrive {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "HD({},{},{})",
+            self.partition_number, self.partition_sig, self.sig_type
+        )
+    }
+}
+
+impl DevicePath {
+    pub fn parse(buf: &mut &[u8]) -> Option<DevicePath> {
+        let r#type = buf.read_u8().unwrap();
+        let subtype = buf.read_u8().unwrap();
+        let length = buf.read_u16::<LittleEndian>().unwrap();
+
+        let data_size = length - 1 - 1 - 2;
+
+        let (mut device_path_data, new_buf) = buf.split_at(data_size.into());
+        *buf = new_buf;
+
+        #[allow(clippy::single_match)]
+        match r#type {
+            consts::DEVICE_PATH_TYPE::MEDIA_DEVICE_PATH => {
+                match subtype {
+                    consts::MEDIA_DEVICE_PATH_SUBTYPE::FILE_PATH => {
+                        return Some(DevicePath::FilePath(
+                            read_nt_utf16_string(&mut device_path_data).into(),
+                        ));
+                    }
+                    consts::MEDIA_DEVICE_PATH_SUBTYPE::HARD_DRIVE => {
+                        return Some(DevicePath::HardDrive(EFIHardDrive {
+                            partition_number: device_path_data.read_u32::<LittleEndian>().unwrap(),
+                            partition_start: device_path_data.read_u64::<LittleEndian>().unwrap(),
+                            partition_size: device_path_data.read_u64::<LittleEndian>().unwrap(),
+                            partition_sig: Uuid::from_u128(
+                                device_path_data.read_u128::<LittleEndian>().unwrap(),
+                            ),
+                            format: device_path_data.read_u8().unwrap(),
+                            sig_type: device_path_data.read_u8().unwrap(),
+                        }));
+                    }
+                    _ => {
+                        // panic!("Invalid media file path type");
+                    }
+                }
+            }
+            _ => {
+                // panic!("Invalid file path type");
+            }
+        };
+
+        None
+    }
+}

--- a/efivar/src/boot/parse/device_path.rs
+++ b/efivar/src/boot/parse/device_path.rs
@@ -52,7 +52,7 @@ impl Display for EFIHardDrive {
         write!(
             f,
             "HD({},{},{})",
-            self.partition_number, self.partition_sig, self.sig_type
+            self.partition_number, self.sig_type, self.partition_sig
         )
     }
 }

--- a/efivar/src/boot/parse/device_path.rs
+++ b/efivar/src/boot/parse/device_path.rs
@@ -12,13 +12,39 @@ pub enum DevicePath {
     HardDrive(EFIHardDrive),
 }
 
+pub enum EFIHardDriveType {
+    Mbr,
+    Gpt,
+    Unknown,
+}
+
+impl EFIHardDriveType {
+    pub fn parse(sig_type: u8) -> EFIHardDriveType {
+        match sig_type {
+            0x01 => Self::Mbr,
+            0x02 => Self::Gpt,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl Display for EFIHardDriveType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EFIHardDriveType::Mbr => f.write_str("MBR"),
+            EFIHardDriveType::Gpt => f.write_str("GPT"),
+            EFIHardDriveType::Unknown => f.write_str("Unknown"),
+        }
+    }
+}
+
 pub struct EFIHardDrive {
     pub partition_number: u32,
     pub partition_start: u64,
     pub partition_size: u64,
     pub partition_sig: Uuid,
     pub format: u8,
-    pub sig_type: u8,
+    pub sig_type: EFIHardDriveType,
 }
 
 impl Display for EFIHardDrive {
@@ -60,7 +86,7 @@ impl DevicePath {
                                 device_path_data.read_u128::<LittleEndian>().unwrap(),
                             ),
                             format: device_path_data.read_u8().unwrap(),
-                            sig_type: device_path_data.read_u8().unwrap(),
+                            sig_type: EFIHardDriveType::parse(device_path_data.read_u8().unwrap()),
                         }));
                     }
                     _ => {

--- a/efivar/src/boot/parse/device_path.rs
+++ b/efivar/src/boot/parse/device_path.rs
@@ -70,33 +70,27 @@ impl DevicePath {
 
         #[allow(clippy::single_match)]
         match r#type {
-            consts::DEVICE_PATH_TYPE::MEDIA_DEVICE_PATH => {
-                match subtype {
-                    consts::MEDIA_DEVICE_PATH_SUBTYPE::FILE_PATH => {
-                        return Some(DevicePath::FilePath(
-                            read_nt_utf16_string(&mut device_path_data).into(),
-                        ));
-                    }
-                    consts::MEDIA_DEVICE_PATH_SUBTYPE::HARD_DRIVE => {
-                        return Some(DevicePath::HardDrive(EFIHardDrive {
-                            partition_number: device_path_data.read_u32::<LittleEndian>().unwrap(),
-                            partition_start: device_path_data.read_u64::<LittleEndian>().unwrap(),
-                            partition_size: device_path_data.read_u64::<LittleEndian>().unwrap(),
-                            partition_sig: Uuid::from_u128(
-                                device_path_data.read_u128::<LittleEndian>().unwrap(),
-                            ),
-                            format: device_path_data.read_u8().unwrap(),
-                            sig_type: EFIHardDriveType::parse(device_path_data.read_u8().unwrap()),
-                        }));
-                    }
-                    _ => {
-                        // panic!("Invalid media file path type");
-                    }
+            consts::DEVICE_PATH_TYPE::MEDIA_DEVICE_PATH => match subtype {
+                consts::MEDIA_DEVICE_PATH_SUBTYPE::FILE_PATH => {
+                    return Some(DevicePath::FilePath(
+                        read_nt_utf16_string(&mut device_path_data).into(),
+                    ));
                 }
-            }
-            _ => {
-                // panic!("Invalid file path type");
-            }
+                consts::MEDIA_DEVICE_PATH_SUBTYPE::HARD_DRIVE => {
+                    return Some(DevicePath::HardDrive(EFIHardDrive {
+                        partition_number: device_path_data.read_u32::<LittleEndian>().unwrap(),
+                        partition_start: device_path_data.read_u64::<LittleEndian>().unwrap(),
+                        partition_size: device_path_data.read_u64::<LittleEndian>().unwrap(),
+                        partition_sig: Uuid::from_u128(
+                            device_path_data.read_u128::<LittleEndian>().unwrap(),
+                        ),
+                        format: device_path_data.read_u8().unwrap(),
+                        sig_type: EFIHardDriveType::parse(device_path_data.read_u8().unwrap()),
+                    }));
+                }
+                _ => {}
+            },
+            _ => {}
         };
 
         None

--- a/efivar/src/boot/parse/device_path_list.rs
+++ b/efivar/src/boot/parse/device_path_list.rs
@@ -15,6 +15,15 @@ pub struct FilePathList {
     pub hard_drive: EFIHardDrive,
 }
 
+impl From<OptFilePathList> for Option<FilePathList> {
+    fn from(value: OptFilePathList) -> Self {
+        Some(FilePathList {
+            file_path: value.file_path?,
+            hard_drive: value.hard_drive?,
+        })
+    }
+}
+
 impl Display for FilePathList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}/File({})", self.hard_drive, self.file_path.display())
@@ -22,16 +31,7 @@ impl Display for FilePathList {
 }
 
 impl FilePathList {
-    pub fn parse(full_buf: &mut &[u8]) -> Option<FilePathList> {
-        let opt_file_path_list = Self::parse_opt(full_buf);
-
-        Some(FilePathList {
-            file_path: opt_file_path_list.file_path?,
-            hard_drive: opt_file_path_list.hard_drive?,
-        })
-    }
-
-    pub fn parse_opt(full_buf: &mut &[u8]) -> OptFilePathList {
+    pub fn parse(full_buf: &mut &[u8]) -> crate::Result<OptFilePathList> {
         let mut file_path_list = OptFilePathList {
             file_path: None,
             hard_drive: None,
@@ -41,7 +41,7 @@ impl FilePathList {
             if full_buf.is_empty() {
                 break;
             } else {
-                match DevicePath::parse(full_buf) {
+                match DevicePath::parse(full_buf)? {
                     Some(DevicePath::FilePath(inner_path)) => {
                         file_path_list.file_path = Some(inner_path);
                     }
@@ -53,6 +53,6 @@ impl FilePathList {
             };
         }
 
-        file_path_list
+        Ok(file_path_list)
     }
 }

--- a/efivar/src/boot/parse/device_path_list.rs
+++ b/efivar/src/boot/parse/device_path_list.rs
@@ -17,7 +17,7 @@ pub struct FilePathList {
 
 impl Display for FilePathList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}\\File({})", self.hard_drive, self.file_path.display())
+        write!(f, "{}/File({})", self.hard_drive, self.file_path.display())
     }
 }
 

--- a/efivar/src/boot/parse/device_path_list.rs
+++ b/efivar/src/boot/parse/device_path_list.rs
@@ -1,0 +1,58 @@
+use std::{fmt::Display, path::PathBuf};
+
+use super::{DevicePath, EFIHardDrive};
+
+/// holds the potential fields we may get from a packed file path list
+pub struct OptFilePathList {
+    pub file_path: Option<PathBuf>,
+    pub hard_drive: Option<EFIHardDrive>,
+}
+
+/// Same structure as OptFilePathList, but we ensure that the file path list
+/// is a valid file path overall
+pub struct FilePathList {
+    pub file_path: PathBuf,
+    pub hard_drive: EFIHardDrive,
+}
+
+impl Display for FilePathList {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}\\File({})", self.hard_drive, self.file_path.display())
+    }
+}
+
+impl FilePathList {
+    pub fn parse(full_buf: &mut &[u8]) -> Option<FilePathList> {
+        let opt_file_path_list = Self::parse_opt(full_buf);
+
+        Some(FilePathList {
+            file_path: opt_file_path_list.file_path?,
+            hard_drive: opt_file_path_list.hard_drive?,
+        })
+    }
+
+    pub fn parse_opt(full_buf: &mut &[u8]) -> OptFilePathList {
+        let mut file_path_list = OptFilePathList {
+            file_path: None,
+            hard_drive: None,
+        };
+
+        loop {
+            if full_buf.is_empty() {
+                break;
+            } else {
+                match DevicePath::parse(full_buf) {
+                    Some(DevicePath::FilePath(inner_path)) => {
+                        file_path_list.file_path = Some(inner_path);
+                    }
+                    Some(DevicePath::HardDrive(inner_hard_drive)) => {
+                        file_path_list.hard_drive = Some(inner_hard_drive);
+                    }
+                    None => {}
+                };
+            };
+        }
+
+        file_path_list
+    }
+}

--- a/efivar/src/error.rs
+++ b/efivar/src/error.rs
@@ -32,6 +32,8 @@ pub enum Error {
     BufferTooSmall { name: VariableName },
     #[fail(display = "failed to decode uuid: {}", error)]
     UuidError { error: uuid::Error },
+    #[fail(display = "failed to parse variable content (invalid content)")]
+    VarParseError,
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/efivar/src/lib.rs
+++ b/efivar/src/lib.rs
@@ -32,11 +32,14 @@ pub mod efi;
 #[cfg(feature = "store")]
 pub mod store;
 
+pub mod boot;
 mod enumerator;
 mod error;
 mod reader;
 mod sys;
 mod writer;
+
+use boot::BootVarReader;
 
 pub use crate::enumerator::VarEnumerator;
 pub use crate::reader::*;
@@ -48,7 +51,7 @@ pub use crate::error::Error;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Represents an EFI variable manager that can read, write and list variables
-pub trait VarManager: VarEnumerator + VarReader + VarWriter {}
+pub trait VarManager: VarEnumerator + VarReader + VarWriter + BootVarReader {}
 
 /// Represents an EFI variable manager that can read (both static and dynamic sized variables),
 /// write and list variables

--- a/efivar/src/sys/windows.rs
+++ b/efivar/src/sys/windows.rs
@@ -40,39 +40,6 @@ impl SystemManager {
     }
 }
 
-struct BootOrderIterator {
-    cursor: Cursor<Vec<u8>>,
-}
-
-impl BootOrderIterator {
-    fn new(sm: &SystemManager) -> crate::Result<BootOrderIterator> {
-        // Buffer for BootOrder
-        let mut buf = vec![0u8; 512];
-
-        // Read BootOrder
-        let (boot_order_size, _flags) = sm.read(&VariableName::new("BootOrder"), &mut buf[..])?;
-
-        // Resize to actual value size
-        buf.resize(boot_order_size, 0);
-
-        Ok(BootOrderIterator {
-            cursor: Cursor::new(buf),
-        })
-    }
-}
-
-impl Iterator for BootOrderIterator {
-    type Item = VariableName;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Ok(id) = self.cursor.read_u16::<LittleEndian>() {
-            Some(VariableName::new(&format!("Boot{:04X}", id)))
-        } else {
-            None
-        }
-    }
-}
-
 impl VarEnumerator for SystemManager {
     fn get_var_names<'a>(&'a self) -> crate::Result<Box<dyn Iterator<Item = VariableName> + 'a>> {
         // Windows doesn't provide access to the variable enumeration service

--- a/efivar/src/sys/windows.rs
+++ b/efivar/src/sys/windows.rs
@@ -1,6 +1,5 @@
 pub struct SystemManager;
 
-use std::io::Cursor;
 use std::iter;
 
 use std::ffi::OsStr;
@@ -10,8 +9,7 @@ use std::os::windows::ffi::OsStrExt;
 use winapi::ctypes::c_void;
 use winapi::um::winbase::{GetFirmwareEnvironmentVariableExW, SetFirmwareEnvironmentVariableExW};
 
-use byteorder::{LittleEndian, ReadBytesExt};
-
+use crate::boot::BootVarReader;
 use crate::efi::{VariableFlags, VariableName};
 use crate::{Error, VarEnumerator, VarManager, VarReader, VarWriter};
 
@@ -50,7 +48,7 @@ impl VarEnumerator for SystemManager {
                 .chain(iter::once(VariableName::new("BootNext")))
                 .chain(iter::once(VariableName::new("BootOrder")))
                 .chain(iter::once(VariableName::new("Timeout")))
-                .chain(BootOrderIterator::new(self)?),
+                .chain(self.get_boot_order()?),
         ))
     }
 }


### PR DESCRIPTION
This PR add the commands `efiboot boot get-order` and `efiboot boot get-entries`

`efiboot boot get-order` output:
```
Boot order:
Boot0001
Boot0003
Boot2001
Boot2002
Boot2003
```

`efiboot boot get-entries` output:
```
Boot entries (in boot order):

Description: GRUB
Enabled: true
Boot file: HD(1,GPT,0ac986f5-a335-f2a8-4943-3ef0837cdce3)/File(\EFI\arch\grubx64.efi)

Description: Windows Boot Manager
Enabled: false
Boot file: HD(1,GPT,0ac986f5-a335-f2a8-4943-3ef0837cdce3)/File(\EFI\Microsoft\Boot\bootmgfw.efi)

Description: EFI USB Device
Enabled: true
Boot file: None/Invalid

Description: EFI DVD/CDROM
Enabled: true
Boot file: None/Invalid

Description: EFI Network
Enabled: true
Boot file: None/Invalid
```

`efiboot boot get-entries -v` output:
```
Boot entries (in boot order):

Description: GRUB
Enabled: true
Boot file: HD(1,GPT,0ac986f5-a335-f2a8-4943-3ef0837cdce3)/File(\EFI\arch\grubx64.efi)
Optional data: None
Attributes: LOAD_OPTION_ACTIVE

Description: Windows Boot Manager
Enabled: false
Boot file: HD(1,GPT,0ac986f5-a335-f2a8-4943-3ef0837cdce3)/File(\EFI\Microsoft\Boot\bootmgfw.efi)
Optional data: 57 49 4e 44 4f 57 53 00 01 00 00 00 88 00 00 00 78 00 00 00 42 00 43 00 44 00 4f 00 42 00 4a 00 45 00 43 00 54 00 3d 00 7b 00 39 00 64 00 65 00 61 00 38 00 36 00 32 00 63 00 2d 00 35 00 63 00 64 00 64 00 2d 00 34 00 65 00 37 00 30 00 2d 00 61 00 63 00 63 00 31 00 2d 00 66 00 33 00 32 00 62 00 33 00 34 00 34 00 64 00 34 00 37 00 39 00 35 00 7d 00 00 00 64 00 01 00 00 00 10 00 00 00 04 00 00 00 7f ff 04 00
Attributes: None

Description: EFI USB Device
Enabled: true
Boot file: None/Invalid
Optional data: 52 43
Attributes: LOAD_OPTION_ACTIVE

Description: EFI DVD/CDROM
Enabled: true
Boot file: None/Invalid
Optional data: 52 43
Attributes: LOAD_OPTION_ACTIVE

Description: EFI Network
Enabled: true
Boot file: None/Invalid
Optional data: 52 43
Attributes: LOAD_OPTION_ACTIVE
```