### PR TITLE
feat: Add efiboot delete

### DIFF
--- a/efiboot/src/cli.rs
+++ b/efiboot/src/cli.rs
@@ -1,4 +1,6 @@
+mod delete;
 mod list;
 mod read;
+pub use self::delete::run as delete;
 pub use self::list::run as list;
 pub use self::read::run as read;

--- a/efiboot/src/cli/delete.rs
+++ b/efiboot/src/cli/delete.rs
@@ -1,0 +1,16 @@
+use efivar::{
+    efi::{VariableName, VariableVendor},
+    VarManager,
+};
+
+pub fn run(mut manager: Box<dyn VarManager>, name: &str, namespace: Option<uuid::Uuid>) {
+    let var_name = VariableName::new_with_vendor(
+        name,
+        namespace.map_or(VariableVendor::Efi, VariableVendor::Custom),
+    );
+
+    match manager.delete(&var_name) {
+        Ok(_) => println!("Deleted variable {var_name} successfully"),
+        Err(err) => eprintln!("Failed to delete variable {var_name}: {err}"),
+    }
+}

--- a/efiboot/src/main.rs
+++ b/efiboot/src/main.rs
@@ -24,6 +24,16 @@ enum Command {
         #[structopt(short, long)]
         all: bool,
     },
+    /// Delete an EFI variabe
+    Delete {
+        /// Name of the variable to delete
+        #[structopt(value_name = "VARIABLE")]
+        name: String,
+
+        /// GUID of the namespace. Default: EFI standard namespace
+        #[structopt(value_name = "GUID")]
+        namespace: Option<uuid::Uuid>,
+    },
 }
 
 #[derive(StructOpt)]
@@ -57,6 +67,9 @@ fn main(opts: Opt) {
         }
         Command::List { namespace, all } => {
             cli::list(manager, namespace, all);
+        }
+        Command::Delete { name, namespace } => {
+            cli::delete(manager, &name, namespace);
         }
     }
 }

--- a/efivar/src/store/guid_group.rs
+++ b/efivar/src/store/guid_group.rs
@@ -21,4 +21,9 @@ impl GuidGroup {
             .entry(String::from(name))
             .or_insert_with(StoreValue::new)
     }
+
+    /// Delete a variable from this GUID group.
+    pub fn del_variable(&mut self, name: &str) {
+        self.values.remove(name);
+    }
 }

--- a/efivar/src/store/variable.rs
+++ b/efivar/src/store/variable.rs
@@ -56,6 +56,13 @@ impl<T: VariableStore> VarWriter for T {
 
         Ok(())
     }
+
+    fn delete(&mut self, name: &VariableName) -> crate::Result<()> {
+        self.get_vendor_group_mut()
+            .vendor_mut(name.vendor())
+            .del_variable(name.variable());
+        Ok(())
+    }
 }
 
 impl<T: VariableStore> VarManager for T {}

--- a/efivar/src/sys/linux.rs
+++ b/efivar/src/sys/linux.rs
@@ -76,6 +76,10 @@ impl VarWriter for SystemManager {
     ) -> crate::Result<()> {
         self.sys_impl.write(name, attributes, value)
     }
+
+    fn delete(&mut self, name: &VariableName) -> crate::Result<()> {
+        self.sys_impl.delete(name)
+    }
 }
 
 impl VarManager for SystemManager {}

--- a/efivar/src/sys/linux/efivarfs.rs
+++ b/efivar/src/sys/linux/efivarfs.rs
@@ -126,6 +126,11 @@ impl VarWriter for SystemManager {
 
         Ok(())
     }
+
+    fn delete(&mut self, _name: &VariableName) -> crate::Result<()> {
+        // I wasn't able to enable efivars sysfs on my system
+        unimplemented!();
+    }
 }
 
 impl VarManager for SystemManager {}

--- a/efivar/src/sys/linux/efivars.rs
+++ b/efivar/src/sys/linux/efivars.rs
@@ -121,6 +121,11 @@ impl VarWriter for SystemManager {
 
         Ok(())
     }
+
+    fn delete(&mut self, name: &VariableName) -> crate::Result<()> {
+        std::fs::remove_file(format!("{}/{}", EFIVARS_ROOT, name))
+            .map_err(|error| Error::for_variable(error, name))
+    }
 }
 
 impl VarManager for SystemManager {}

--- a/efivar/src/sys/windows.rs
+++ b/efivar/src/sys/windows.rs
@@ -143,6 +143,25 @@ impl VarWriter for SystemManager {
             _ => Ok(()),
         }
     }
+
+    fn delete(&mut self, name: &VariableName) -> crate::Result<()> {
+        let (guid_wide, name_wide) = SystemManager::parse_name(name)?;
+
+        let result = unsafe {
+            SetFirmwareEnvironmentVariableExW(
+                name_wide.as_ptr(),
+                guid_wide.as_ptr(),
+                mem::transmute::<*const u8, *mut c_void>(std::ptr::null()),
+                0,
+                VariableFlags::NON_VOLATILE.bits(),
+            )
+        };
+
+        match result {
+            0 => Err(Error::for_variable_os(name)),
+            _ => Ok(()),
+        }
+    }
 }
 
 impl VarManager for SystemManager {}

--- a/efivar/src/writer.rs
+++ b/efivar/src/writer.rs
@@ -17,4 +17,6 @@ pub trait VarWriter {
         attributes: VariableFlags,
         value: &[u8],
     ) -> crate::Result<()>;
+
+    fn delete(&mut self, name: &VariableName) -> crate::Result<()>;
 }


### PR DESCRIPTION
This PR adds a `efiboot delete` command, that can be used to delete EFI variables

Note: I did not add support for the `efivarsfs` backend, because I wasn't able to enable it for testing in my computer