### PR TITLE
feat: add `efiboot dump` and `efiboot import`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
 name = "efiboot"
 version = "1.1.3"
 dependencies = [
+ "byteorder",
  "efivar",
  "itertools",
  "paw",

--- a/efiboot/Cargo.toml
+++ b/efiboot/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 
 [dependencies]
 efivar = { version = "1.1.3", path = "../efivar", features = ["store"] }
+byteorder = "1.4.3"
 itertools = "0.11.0"
 paw = "1.0.0"
 structopt = { version = "0.3.26", features = ["paw"] }

--- a/efiboot/src/cli.rs
+++ b/efiboot/src/cli.rs
@@ -1,7 +1,9 @@
 mod dump;
+mod import;
 mod list;
 mod read;
 
 pub use self::dump::run as dump;
+pub use self::import::run as import;
 pub use self::list::run as list;
 pub use self::read::run as read;

--- a/efiboot/src/cli.rs
+++ b/efiboot/src/cli.rs
@@ -1,4 +1,7 @@
+mod dump;
 mod list;
 mod read;
+
+pub use self::dump::run as dump;
 pub use self::list::run as list;
 pub use self::read::run as read;

--- a/efiboot/src/cli/dump.rs
+++ b/efiboot/src/cli/dump.rs
@@ -1,0 +1,39 @@
+use std::{fs::File, io::Write, path::Path};
+
+use uuid::Uuid;
+
+use efivar::{
+    efi::{VariableFlags, VariableName, VariableVendor},
+    VarManager,
+};
+
+fn dump(output_path: &Path, flags: VariableFlags, data: &[u8]) -> Result<(), std::io::Error> {
+    let mut file = File::create(output_path)?;
+    file.write_all(&flags.bits().to_le_bytes())?;
+    file.write_all(data)?;
+
+    Ok(())
+}
+
+pub fn run(reader: Box<dyn VarManager>, name: &str, namespace: Option<Uuid>, output_path: &Path) {
+    let var = VariableName::new_with_vendor(
+        name,
+        namespace.map_or(VariableVendor::Efi, VariableVendor::Custom),
+    );
+
+    let mut buf = vec![0u8; 512];
+    match reader.read(&var, &mut buf) {
+        Ok((size, flags)) => {
+            buf.resize(size, 0);
+            match dump(output_path, flags, &buf) {
+                Ok(_) => println!(
+                    "Dumped variable {} to file {}",
+                    var,
+                    output_path.canonicalize().unwrap().display()
+                ),
+                Err(err) => eprintln!("Failed to write to file: {}", err),
+            }
+        }
+        Err(err) => eprintln!("Failed to read variable: {}", err),
+    }
+}

--- a/efiboot/src/cli/import.rs
+++ b/efiboot/src/cli/import.rs
@@ -1,0 +1,45 @@
+use std::{fs::File, io::Read, path::Path};
+
+use uuid::Uuid;
+
+use byteorder::{LittleEndian, ReadBytesExt};
+
+use efivar::{
+    efi::{VariableFlags, VariableName, VariableVendor},
+    VarManager,
+};
+
+fn read_var_from_file(input_path: &Path) -> Result<(VariableFlags, Vec<u8>), std::io::Error> {
+    let mut file = File::open(input_path)?;
+
+    let flags = VariableFlags::from_bits(file.read_u32::<LittleEndian>()?).unwrap();
+    let mut data = Vec::new();
+    file.read_to_end(&mut data)?;
+
+    Ok((flags, data))
+}
+
+pub fn run(
+    mut manager: Box<dyn VarManager>,
+    input_path: &Path,
+    name: &str,
+    namespace: Option<Uuid>,
+) {
+    let var = VariableName::new_with_vendor(
+        name,
+        namespace.map_or(VariableVendor::Efi, VariableVendor::Custom),
+    );
+
+    let (flags, data) = match read_var_from_file(input_path) {
+        Ok(inner) => inner,
+        Err(err) => {
+            eprintln!("Failed to read variable from file {}: {}", input_path.display(), err);
+            return;
+        }
+    };
+
+    match manager.write(&var, flags, &data) {
+        Ok(()) => println!("Imported variable {} with success", var),
+        Err(err) => eprintln!("Failed to write variable {}: {}", var, err),
+    }
+}

--- a/efiboot/src/main.rs
+++ b/efiboot/src/main.rs
@@ -24,6 +24,20 @@ enum Command {
         #[structopt(short, long)]
         all: bool,
     },
+    /// Dump a variable to file
+    Dump {
+        /// Name of the variable to dump
+        #[structopt(value_name = "VARIABLE")]
+        name: String,
+
+        /// GUID of the namespace. Default: EFI standard namespace
+        #[structopt(short, long, value_name = "NAMESPACE")]
+        namespace: Option<uuid::Uuid>,
+
+        /// Output file
+        #[structopt(value_name = "OUTPUT_FILE")]
+        output_file: PathBuf,
+    },
 }
 
 #[derive(StructOpt)]
@@ -57,6 +71,13 @@ fn main(opts: Opt) {
         }
         Command::List { namespace, all } => {
             cli::list(manager, namespace, all);
+        }
+        Command::Dump {
+            name,
+            namespace,
+            output_file,
+        } => {
+            cli::dump(manager, &name, namespace, &output_file);
         }
     }
 }

--- a/efiboot/src/main.rs
+++ b/efiboot/src/main.rs
@@ -38,6 +38,20 @@ enum Command {
         #[structopt(value_name = "OUTPUT_FILE")]
         output_file: PathBuf,
     },
+    /// Import a variable from a file
+    Import {
+        /// Input file
+        #[structopt(value_name = "OUTPUT_FILE")]
+        input_file: PathBuf,
+
+        /// Name of the variable to create
+        #[structopt(value_name = "VARIABLE")]
+        name: String,
+
+        /// GUID of the namespace. Default: EFI standard namespace
+        #[structopt(short, long, value_name = "NAMESPACE")]
+        namespace: Option<uuid::Uuid>,
+    },
 }
 
 #[derive(StructOpt)]
@@ -78,6 +92,13 @@ fn main(opts: Opt) {
             output_file,
         } => {
             cli::dump(manager, &name, namespace, &output_file);
+        }
+        Command::Import {
+            input_file,
+            name,
+            namespace,
+        } => {
+            cli::import(manager, &input_file, &name, namespace);
         }
     }
 }


### PR DESCRIPTION
This PR adds the commands `efiboot dump` and `efiboot import`

These commands dump a variable flags and content to file, and restore it from file

Syntax:
`efiboot dump Boot0001 a.bin`
`efiboot import a.bin Boot1000`